### PR TITLE
Bumping versions of dependencies to address CVEs

### DIFF
--- a/sensu-plugins-f5.gemspec
+++ b/sensu-plugins-f5.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 10.5'
   s.add_development_dependency 'redcarpet',                 '~> 3.2'
-  s.add_development_dependency 'rubocop',                   '~> 0.40.0'
+  s.add_development_dependency 'rubocop',                   '~> 0.49.0'
   s.add_development_dependency 'rspec',                     '~> 3.4'
-  s.add_development_dependency 'yard',                      '~> 0.8'
+  s.add_development_dependency 'yard',                      '~> 0.9.20'
 end


### PR DESCRIPTION
There are older version of rake and rubocop here that have vulnerable CVEs, let's squash that.